### PR TITLE
Update bluez.py read_local_bdaddr()

### DIFF
--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -2,7 +2,7 @@ import sys
 import struct
 from errno import (EADDRINUSE, EBUSY, EINVAL)
 
-if sys.version < '3':
+if sys.version_info.major < 3:
     from .btcommon import *
     import _bluetooth as _bt
     get_byte = ord

--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -75,7 +75,7 @@ def read_local_bdaddr():
         status,raw_bdaddr = struct.unpack("xxxxxxB6s", pkt)
         assert status == 0
 
-        t = [ "%X" % get_byte(b) for b in raw_bdaddr ]
+        t = [ "%02X" % get_byte(b) for b in raw_bdaddr ]
         t.reverse()
         bdaddr = ":".join(t)
 


### PR DESCRIPTION
When we use the BD_ADDR as a string, each byte of the BD_ADDR should be converted into two hexadecimal digits, not one hexadecimal digit. Otherwise we might fail to call `hci_devid()` using the return value, for example `['0:XX:XX:XX:XX:XX']`, of the `read_local_bdaddr()`.